### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_tideebayesian.yml
+++ b/.github/workflows/main_tideebayesian.yml
@@ -3,6 +3,8 @@
 # More info on Python, GitHub Actions, and Azure App Service: https://aka.ms/python-webapps-actions
 
 name: Build and deploy Python app to Azure Web App - tideebayesian
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/onecheckshot_inversion_app/security/code-scanning/2](https://github.com/equinor/onecheckshot_inversion_app/security/code-scanning/2)

In general, the problem is fixed by explicitly specifying a `permissions` block either at the workflow root (applying to all jobs) or on individual jobs, restricting the GITHUB_TOKEN scopes to the minimal set actually needed. For this workflow, the jobs only need to read repository contents (for `actions/checkout`) and use GitHub Actions infrastructure; they do not appear to modify code, issues, or pull requests.

The simplest, least intrusive fix that preserves existing behavior is to add a root-level `permissions` block under the `name:` line, setting `contents: read`. This grants read access to the repository contents, sufficient for checking out code and handling artifacts, while avoiding unnecessary write scopes. There is no indication that the workflow needs any other permissions (e.g., `packages`, `pull-requests`, `deployments`), so we should not grant them. No additional imports or external libraries are needed, since this is purely a YAML configuration change within `.github/workflows/main_tideebayesian.yml`.

Concretely:
- Edit `.github/workflows/main_tideebayesian.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the existing `name: Build and deploy Python app to Azure Web App - tideebayesian` line and the `on:` block. This will apply to both `build` and `deploy` jobs and satisfy CodeQL’s requirement for explicit permissions while keeping functionality unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
